### PR TITLE
Enabled support for LaTeX style math in Maruku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,10 @@ gem 'redcarpet', '1.17.2'
 gem 'rdiscount'
 gem 'bluecloth'
 gem 'kramdown'
+
 gem 'maruku'
+# For MathML support in maruku
+gem 'ritex'
 
 # Textile
 gem 'RedCloth'

--- a/lib/markdownr/parser.rb
+++ b/lib/markdownr/parser.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'maruku/ext/math'
 
 module Markdownr
   class Parser
@@ -41,6 +42,7 @@ module Markdownr
       when 'kramdown'
         Kramdown::Document.new(text).to_html
       when 'maruku'
+        Maruku::Globals[:html_math_engine] = 'ritex'
         Maruku.new(text).to_html
       when 'redcloth'
         RedCloth.new(text).to_html


### PR DESCRIPTION
With these changes you can display MathML in markdownr

Example: 

To see it in action, set the Markdown-parse to Maruku and put your LaTeX in double dollars.
`
$$f(x) = \frac{\sin x}{\cos x}$$
`
